### PR TITLE
Fix: Add checks for note ID before creating note vectors

### DIFF
--- a/api/app/clients/tools/structured/Collections.js
+++ b/api/app/clients/tools/structured/Collections.js
@@ -846,6 +846,15 @@ class Collections extends Tool {
 
       const note = noteResult.rows[0];
 
+      // Add this check:
+      if (!note || !note.id) {
+        logger.error('Failed to create note or retrieve note ID after insertion.', {
+          collectionId,
+          title,
+        });
+        throw new Error('Failed to create note or retrieve its ID. Note vector not created.');
+      }
+
       // Generate and store embedding
       const embedding = await this.generateEmbedding(`${title}\n\n${content}`);
       if (embedding) {
@@ -923,6 +932,18 @@ class Collections extends Tool {
           );
 
           const note = noteResult.rows[0];
+
+          // Add this check:
+          if (!note || !note.id) {
+            logger.error('Failed to create note or retrieve note ID during bulk operation.', {
+              collectionId,
+              title: noteData.title,
+            });
+            // This will be caught by the existing catch (noteError) block
+            throw new Error(
+              'Failed to create note or retrieve its ID in bulk. Note vector not created.',
+            );
+          }
 
           // Generate and store embedding
           const embedding = await this.generateEmbedding(


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add validation checks for note ID after database insertion

- Prevent foreign key violations in note_vectors table

- Improve error handling with specific error messages

- Apply defensive programming to both single and bulk operations


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Insert Note"] --> B["Check Note ID"]
  B --> C{Note ID Valid?}
  C -->|Yes| D["Create Note Vector"]
  C -->|No| E["Throw Error"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Collections.js</strong><dd><code>Add note ID validation checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/app/clients/tools/structured/Collections.js

<li>Add validation checks after note insertion in <code>addNote</code> method<br> <li> Add validation checks after note insertion in <code>bulkAddNotes</code> method<br> <li> Include error logging with collection and title context<br> <li> Throw specific errors when note ID is missing or invalid


</details>


  </td>
  <td><a href="https://github.com/jmaddington/LibreChat/pull/94/files#diff-01ee5d6c08af6b1b56fda368afee795f7761d80f7d2ce85896055823d8d748f9">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>